### PR TITLE
Fix Dashboard JSON decoding with CodingKeys

### DIFF
--- a/iOS/YachtLife/YachtLife/Models/Dashboard.swift
+++ b/iOS/YachtLife/YachtLife/Models/Dashboard.swift
@@ -11,6 +11,18 @@ struct DashboardViewModel: Codable {
     let hasDepartureLog: Bool
     let upcomingBookings: [BookingInfo]
     let recentActivities: [ActivityInfo]
+
+    enum CodingKeys: String, CodingKey {
+        case userName = "user_name"
+        case vessel
+        case portEngineHours = "port_engine_hours"
+        case starboardEngineHours = "starboard_engine_hours"
+        case fuelLiters = "fuel_liters"
+        case activeBooking = "active_booking"
+        case hasDepartureLog = "has_departure_log"
+        case upcomingBookings = "upcoming_bookings"
+        case recentActivities = "recent_activities"
+    }
 }
 
 struct VesselInfo: Codable {
@@ -20,6 +32,15 @@ struct VesselInfo: Codable {
     let model: String
     let length: Double
     let homePort: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case manufacturer
+        case model
+        case length
+        case homePort = "home_port"
+    }
 }
 
 struct BookingInfo: Codable, Identifiable {
@@ -29,6 +50,15 @@ struct BookingInfo: Codable, Identifiable {
     let status: String
     let standbyDays: Int
     let notes: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case status
+        case standbyDays = "standby_days"
+        case notes
+    }
 }
 
 struct ActivityInfo: Codable, Identifiable {


### PR DESCRIPTION
## Summary

Fixes JSON decoding error in the Dashboard ViewModel by adding CodingKeys to handle snake_case to camelCase conversion.

## Problem

After PR #12 was merged, the iOS app couldn't decode the dashboard API response because:
- Backend returns snake_case JSON: `user_name`, `port_engine_hours`, `home_port`, etc.
- Swift expects camelCase by default: `userName`, `portEngineHours`, `homePort`, etc.

This caused the error: `keyNotFound(CodingKeys(stringValue: "userName"))`

## Solution

Added `CodingKeys` enums to map JSON keys:

**DashboardViewModel:**
- `user_name` → `userName`
- `port_engine_hours` → `portEngineHours`
- `starboard_engine_hours` → `starboardEngineHours`
- `fuel_liters` → `fuelLiters`
- `active_booking` → `activeBooking`
- `has_departure_log` → `hasDepartureLog`
- `upcoming_bookings` → `upcomingBookings`
- `recent_activities` → `recentActivities`

**VesselInfo:**
- `home_port` → `homePort`

**BookingInfo:**
- `start_date` → `startDate`
- `end_date` → `endDate`
- `standby_days` → `standbyDays`

## Testing

Dashboard now loads correctly with proper fuel/engine hours values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data model compatibility to ensure proper handling of API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->