### PR TITLE
Fix UserRole decoding to handle empty strings

### DIFF
--- a/iOS/YachtLife/YachtLife/Models/User.swift
+++ b/iOS/YachtLife/YachtLife/Models/User.swift
@@ -15,6 +15,25 @@ struct User: Codable, Identifiable {
         case admin
         case manager
         case owner
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let roleString = try container.decode(String.self)
+
+            // Handle empty string as default "owner" role
+            if roleString.isEmpty {
+                self = .owner
+                return
+            }
+
+            // Try to decode from the string value
+            if let role = UserRole(rawValue: roleString) {
+                self = role
+            } else {
+                // If invalid role, default to owner
+                self = .owner
+            }
+        }
     }
 
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
## Summary

Fixes the logbook entry creation error where the app crashed when trying to decode user roles with empty string values.

## Problem

When creating a logbook entry, the API response includes nested  data. If the role field contains an empty string , the Swift  enum fails to decode it, causing this error:

```
decodingError(Swift.DecodingError.dataCorrupted(
  Swift.DecodingError.Context(
    codingPath: [booking, user, role],
    debugDescription: "Cannot initialize UserRole from invalid String value "
  )
))
```

## Solution

Added a custom `init(from:)` decoder to the `UserRole` enum that:
- Handles empty string `""` values by defaulting to `.owner`
- Handles invalid role strings gracefully by defaulting to `.owner`
- Maintains backward compatibility with valid role strings ("admin", "manager", "owner")

## Testing

✅ Successfully created logbook entries  
✅ Booking details now show return logs and fuel stats  
✅ No decoding errors when user role is empty or invalid  

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness in handling user role data, ensuring the app gracefully manages edge cases when role information is missing or unexpected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->