### PR TITLE
Fix log button logic to prevent duplicate return logs

### DIFF
--- a/backend/internal/api/handlers/dashboard_handler.go
+++ b/backend/internal/api/handlers/dashboard_handler.go
@@ -41,6 +41,8 @@ func (h *DashboardHandler) GetDashboard(c *gin.Context) {
 	}
 
 	viewModel := models.DashboardViewModel{
+		HasDepartureLog:  false,
+		HasReturnLog:     false,
 		UpcomingBookings: []models.BookingInfo{},
 		RecentActivities: []models.ActivityInfo{},
 	}

--- a/backend/internal/api/handlers/dashboard_handler.go
+++ b/backend/internal/api/handlers/dashboard_handler.go
@@ -113,6 +113,12 @@ func (h *DashboardHandler) GetDashboard(c *gin.Context) {
 		err = h.db.Where("booking_id = ? AND entry_type = ?", activeBooking.ID, "depart").
 			First(&departureLog).Error
 		viewModel.HasDepartureLog = (err == nil)
+
+		// Check for return log
+		var returnLog models.LogbookEntry
+		err = h.db.Where("booking_id = ? AND entry_type = ?", activeBooking.ID, "return").
+			First(&returnLog).Error
+		viewModel.HasReturnLog = (err == nil)
 	}
 
 	// 5. Get upcoming bookings (next 3 for this user)

--- a/backend/internal/models/dashboard.go
+++ b/backend/internal/models/dashboard.go
@@ -21,6 +21,7 @@ type DashboardViewModel struct {
 	// Booking status
 	ActiveBooking   *BookingInfo `json:"active_booking,omitempty"`
 	HasDepartureLog bool         `json:"has_departure_log"`
+	HasReturnLog    bool         `json:"has_return_log"`
 
 	// Upcoming bookings (next 3)
 	UpcomingBookings []BookingInfo `json:"upcoming_bookings"`

--- a/iOS/YachtLife/YachtLife/Models/Dashboard.swift
+++ b/iOS/YachtLife/YachtLife/Models/Dashboard.swift
@@ -9,6 +9,7 @@ struct DashboardViewModel: Codable {
     let fuelLiters: Double
     let activeBooking: BookingInfo?
     let hasDepartureLog: Bool
+    let hasReturnLog: Bool
     let upcomingBookings: [BookingInfo]
     let recentActivities: [ActivityInfo]
 
@@ -20,6 +21,7 @@ struct DashboardViewModel: Codable {
         case fuelLiters = "fuel_liters"
         case activeBooking = "active_booking"
         case hasDepartureLog = "has_departure_log"
+        case hasReturnLog = "has_return_log"
         case upcomingBookings = "upcoming_bookings"
         case recentActivities = "recent_activities"
     }

--- a/iOS/YachtLife/YachtLife/Views/Dashboard/DashboardView.swift
+++ b/iOS/YachtLife/YachtLife/Views/Dashboard/DashboardView.swift
@@ -120,11 +120,11 @@ struct DashboardView: View {
         if data.activeBooking != nil {
             if !data.hasDepartureLog {
                 return "Create Departure Log"
-            } else {
+            } else if !data.hasReturnLog {
                 return "Create Return Log"
             }
         }
-        return "Create Trip Log"
+        return "View / Edit Logs"
     }
 }
 


### PR DESCRIPTION
## 🐛 Fix: Log Button Logic (Issue #27)

### Problem
The dashboard log button had incorrect logic that caused:
1. ❌ Missing return log check → allowed duplicate return logs to be created
2. ❌ Wrong default text → showed "Create Trip Log" instead of "View / Edit Logs"
3. ❌ Only 2 states instead of required 3 states

### Solution
Implemented proper 3-state logic for the log button:

**State 1:** Active booking + no departure log
- ✅ Shows: "Create Departure Log"

**State 2:** Active booking + has departure + no return log
- ✅ Shows: "Create Return Log"

**State 3:** No active booking OR both logs complete
- ✅ Shows: "View / Edit Logs"

---

## 📝 Changes

### Backend Changes:
**`backend/internal/models/dashboard.go`**
- Added `HasReturnLog bool` field to DashboardViewModel

**`backend/internal/api/handlers/dashboard_handler.go`**
- Added query to check for return log in active booking
- Sets `viewModel.HasReturnLog` based on query result

### iOS Changes:
**`iOS/YachtLife/YachtLife/Models/Dashboard.swift`**
- Added `hasReturnLog: Bool` field
- Added CodingKeys mapping for `has_return_log`

**`iOS/YachtLife/YachtLife/Views/Dashboard/DashboardView.swift`**
- Updated `logButtonText()` function with proper 3-state logic
- Added `else if !data.hasReturnLog` check
- Changed default text from "Create Trip Log" to "View / Edit Logs"

---

## ✅ Benefits

- 🛡️ Prevents duplicate return logs
- 🎯 Shows correct button text in all 3 states
- 💡 Better UX with "View / Edit Logs" for completed trips
- 🔄 Proper state management for logbook workflow

---

## 🧪 Testing

**Test Scenarios:**
1. ✅ Active booking + no logs → Shows "Create Departure Log"
2. ✅ Active booking + departure only → Shows "Create Return Log"
3. ✅ Active booking + both logs → Shows "View / Edit Logs"
4. ✅ No active booking → Shows "View / Edit Logs"

---

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now tracks return logs in addition to departure logs for active bookings.

* **Improvements**
  * Dashboard action label logic updated for clarity: shows "Create Departure Log", "Create Return Log", or "View / Edit Logs" based on log presence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->